### PR TITLE
Fixed: tab preview overlaps with other tabs

### DIFF
--- a/Plugins/DynamicPanels/Scripts/Panel.cs
+++ b/Plugins/DynamicPanels/Scripts/Panel.cs
@@ -96,9 +96,10 @@ namespace DynamicPanels
 			public int GetTabIndexAt( PointerEventData pointer, out Vector2 tabPreviewRect ) // x: position, y: size
 			{
 				int tabCount = panel.tabs.Count;
+				float offset = panel.tabsParent.anchoredPosition.x;
 				if( tabCount == 0 )
 				{
-					tabPreviewRect = new Vector2( 0f, panel.Size.x );
+					tabPreviewRect = new Vector2( offset, panel.Size.x );
 					return 0;
 				}
 
@@ -126,11 +127,11 @@ namespace DynamicPanels
 				{
 					float remainingSize = panel.Size.x - tabPosition - tabSize;
 					if( remainingSize < 30f )
-						tabPreviewRect = new Vector2( tabPosition + tabSize * 0.5f, remainingSize + tabSize * 0.5f );
+						tabPreviewRect = new Vector2( offset + tabPosition + tabSize * 0.5f, remainingSize + tabSize * 0.5f );
 					else if( remainingSize > tabSize )
-						tabPreviewRect = new Vector2( tabPosition + tabSize, tabSize );
+						tabPreviewRect = new Vector2( offset + tabPosition + tabSize, tabSize );
 					else
-						tabPreviewRect = new Vector2( tabPosition + tabSize, remainingSize );
+						tabPreviewRect = new Vector2( offset + tabPosition + tabSize, remainingSize );
 
 					return tabCount;
 				}

--- a/Plugins/DynamicPanels/Scripts/Panel.cs
+++ b/Plugins/DynamicPanels/Scripts/Panel.cs
@@ -115,7 +115,7 @@ namespace DynamicPanels
 						if( i > 0 )
 							i--;
 
-						tabPreviewRect = new Vector2( tabPosition, panel.tabs[i].Internal.RectTransform.sizeDelta.x + 4f );
+						tabPreviewRect = new Vector2( offset + tabPosition, panel.tabs[i].Internal.RectTransform.sizeDelta.x + 4f );
 						return i;
 					}
 
@@ -136,7 +136,7 @@ namespace DynamicPanels
 					return tabCount;
 				}
 
-				tabPreviewRect = new Vector2( tabPosition, tabSize + 4f );
+				tabPreviewRect = new Vector2( offset + tabPosition, tabSize + 4f );
 				return tabCount - 1;
 			}
 

--- a/Plugins/DynamicPanels/Scripts/Panel.cs
+++ b/Plugins/DynamicPanels/Scripts/Panel.cs
@@ -115,7 +115,7 @@ namespace DynamicPanels
 						if( i > 0 )
 							i--;
 
-						tabPreviewRect = new Vector2( offset + tabPosition, panel.tabs[i].Internal.RectTransform.sizeDelta.x + 4f );
+						tabPreviewRect = new Vector2( offset + tabPosition, panel.tabs[i].Internal.RectTransform.sizeDelta.x );
 						return i;
 					}
 
@@ -136,7 +136,7 @@ namespace DynamicPanels
 					return tabCount;
 				}
 
-				tabPreviewRect = new Vector2( offset + tabPosition, tabSize + 4f );
+				tabPreviewRect = new Vector2( offset + tabPosition, tabSize );
 				return tabCount - 1;
 			}
 


### PR DESCRIPTION
When docking a tab in a panel, the preview of the tab slightly overlaps with the tab next to it. This is caused by the PanelHeaders RectTransform.anchoredPosition.x beeing set to 2 in the prefab, which is not beeing taken into account when calculating the previews position. The issue becomes more apparent, when the anchored position is increased in the prefab.

**Before**
![before](https://user-images.githubusercontent.com/65354676/145195726-a67d58e2-917b-4320-9019-21576cc2ac24.jpg)


**After**
![after](https://user-images.githubusercontent.com/65354676/145195739-33bc1b4c-eb12-4483-b4f3-ca6517d1cc3e.jpg)

To fix this for all possible cases, the PanelHeaders parent RectTransform and the spacing of the HorizontalLayoutGroup on the PanelHeader would have to be taken into account aswell, however they are probably out of scope, since they both default to 0. If you are interested in that, let me know and I'll update the PR accordingly.