### PR TITLE
Fixed: isQuitting is set true also when quit is canceled

### DIFF
--- a/Plugins/DynamicPanels/Scripts/DynamicPanelsCanvas.cs
+++ b/Plugins/DynamicPanels/Scripts/DynamicPanelsCanvas.cs
@@ -83,7 +83,7 @@ namespace DynamicPanels
 
 			public void AnchorZonesSetActive( bool value ) { canvas.AnchorZonesSetActive( value ); }
 			public void ReceiveRaycasts( bool value ) { canvas.background.raycastTarget = value; }
-			public void OnApplicationQuit() { canvas.OnApplicationQuit(); }
+			public void OnApplicationQuitting() { canvas.OnApplicationQuitting(); }
 		}
 
 		[System.Serializable]
@@ -260,6 +260,8 @@ namespace DynamicPanels
 			}
 
 			PanelManager.Instance.RegisterCanvas( this );
+
+			Application.quitting += OnApplicationQuitting;
 		}
 
 		private void Start()
@@ -323,7 +325,7 @@ namespace DynamicPanels
 				PanelManager.Instance.UnregisterCanvas( this );
 		}
 
-		private void OnApplicationQuit()
+		private void OnApplicationQuitting()
 		{
 			isQuitting = true;
 		}

--- a/Plugins/DynamicPanels/Scripts/Panel.cs
+++ b/Plugins/DynamicPanels/Scripts/Panel.cs
@@ -199,7 +199,7 @@ namespace DynamicPanels
 			public void AnchorZonesSetActive( bool value ) { panel.AnchorZonesSetActive( value ); }
 			public void OnResize( Direction direction, Vector2 screenPoint ) { panel.OnResize( direction, screenPoint ); }
 			public void OnTranslate( Vector2 deltaPosition ) { panel.OnTranslate( deltaPosition ); }
-			public void OnApplicationQuit() { panel.OnApplicationQuit(); }
+			public void OnApplicationQuitting() { panel.OnApplicationQuitting(); }
 		}
 
 		public RectTransform RectTransform { get; private set; }
@@ -366,6 +366,8 @@ namespace DynamicPanels
 
 			closeButton.onClick.AddListener( () => PanelNotificationCenter.Internal.PanelClosed( this ) );
 			closeButton.transform.SetAsLastSibling();
+
+			Application.quitting += OnApplicationQuitting;
 		}
 
 		private void Start()
@@ -407,7 +409,7 @@ namespace DynamicPanels
 			}
 		}
 
-		private void OnApplicationQuit()
+		private void OnApplicationQuitting()
 		{
 			isQuitting = true;
 		}

--- a/Plugins/DynamicPanels/Scripts/PanelManager.cs
+++ b/Plugins/DynamicPanels/Scripts/PanelManager.cs
@@ -56,15 +56,17 @@ namespace DynamicPanels
 
 			nextPanelValidationTime = Time.realtimeSinceStartup + PANEL_TABS_VALIDATE_INTERVAL;
 			nullPointerEventData = new PointerEventData( null );
+
+			Application.quitting += OnApplicationQuitting;
 		}
 
-		private void OnApplicationQuit()
+		private void OnApplicationQuitting()
 		{
 			for( int i = 0; i < panels.Count; i++ )
-				panels[i].Internal.OnApplicationQuit();
+				panels[i].Internal.OnApplicationQuitting();
 
 			for( int i = 0; i < canvases.Count; i++ )
-				canvases[i].Internal.OnApplicationQuit();
+				canvases[i].Internal.OnApplicationQuitting();
 		}
 
 		private void Update()


### PR DESCRIPTION
Before the PR, `DynamicPanelsCanvas.isQuitting` & `Panel.isQuitting` were set to true in `OnApplicationQuit()`. Because Unity invokes `OnApplicationQuit()` even when a method subscribed to `Application.wantsToQuit` returns false, the `isQuitting` fields are set to true also when quitting was in fact canceled, leading to the plugin not beeing cleaned up properly when destroyed afterwards. This PR makes use of `Application.quitting` instead, which is only invoked when the application actually does quit.