### PR TITLE
Fix initial panels being created too large

### DIFF
--- a/Plugins/DynamicPanels/Scripts/Helpers/PanelTab.cs
+++ b/Plugins/DynamicPanels/Scripts/Helpers/PanelTab.cs
@@ -1,4 +1,5 @@
 ﻿using UnityEngine;
+using UnityEngine.Assertions;
 using UnityEngine.EventSystems;
 using UnityEngine.UI;
 
@@ -24,6 +25,7 @@ namespace DynamicPanels
 			{
 				tab.m_panel = panel;
 				tab.Content = content;
+				tab.MinSize = content.rect.size;
 			}
 
 			public void ChangeCloseButtonVisibility( bool isVisible )
@@ -100,6 +102,8 @@ namespace DynamicPanels
 			{
 				if( m_minSize != value )
 				{
+					if (value.x < 0) value = new Vector2(-value.x, value.y);
+					if (value.y < 0) value = new Vector2(value.x, -value.y);
 					m_minSize = value;
 					m_panel.Internal.RecalculateMinSize();
 				}
@@ -133,7 +137,7 @@ namespace DynamicPanels
 
 		private void Awake()
 		{
-			m_minSize = new Vector2( 100f, 100f );
+			m_minSize = new Vector2( -1f, -1f );
 			Internal = new InternalSettings( this );
 
 			iconHolder.preserveAspect = true;

--- a/Plugins/DynamicPanels/Scripts/Panel.cs
+++ b/Plugins/DynamicPanels/Scripts/Panel.cs
@@ -474,11 +474,11 @@ namespace DynamicPanels
 					tab.Panel.Internal.RemoveTab( tab.Index, false );
 				}
 
-				tab.Internal.Initialize( this, tabContent );
-				tab.Internal.RectTransform.SetSiblingIndex( tabIndex );
-
 				tabContent.SetParent( null, false ); // workaround for a rare internal Unity crash
 				tabContent.SetParent( contentParent, false );
+				
+				tab.Internal.Initialize( this, tabContent );
+				tab.Internal.RectTransform.SetSiblingIndex( tabIndex );
 
 				Internal.RecalculateMinSize();
 			}

--- a/Plugins/DynamicPanels/Scripts/Panel.cs
+++ b/Plugins/DynamicPanels/Scripts/Panel.cs
@@ -450,6 +450,7 @@ namespace DynamicPanels
 				tabIndex = tabs.Count;
 
 			int thisTabIndex = GetTabIndex( tabContent );
+			Vector2? newTabContentSize = null;
 			if( thisTabIndex == -1 )
 			{
 				PanelTab tab = PanelUtils.GetAssociatedTab( tabContent );
@@ -458,6 +459,7 @@ namespace DynamicPanels
 					tab = (PanelTab) Instantiate( Resources.Load<PanelTab>( "DynamicPanelTab" ), tabsParent, false );
 					tabs.Insert( tabIndex, tab );
 
+					newTabContentSize = tabContent.rect.size;
 					tabContent.anchorMin = Vector2.zero;
 					tabContent.anchorMax = Vector2.one;
 					tabContent.sizeDelta = Vector2.zero;
@@ -474,11 +476,12 @@ namespace DynamicPanels
 					tab.Panel.Internal.RemoveTab( tab.Index, false );
 				}
 
+				tab.Internal.Initialize( this, tabContent );
+				if (newTabContentSize != null) tab.MinSize = newTabContentSize.Value;
+				tab.Internal.RectTransform.SetSiblingIndex( tabIndex );
+				
 				tabContent.SetParent( null, false ); // workaround for a rare internal Unity crash
 				tabContent.SetParent( contentParent, false );
-				
-				tab.Internal.Initialize( this, tabContent );
-				tab.Internal.RectTransform.SetSiblingIndex( tabIndex );
 
 				Internal.RecalculateMinSize();
 			}

--- a/Plugins/DynamicPanels/Scripts/Panel.cs
+++ b/Plugins/DynamicPanels/Scripts/Panel.cs
@@ -273,7 +273,7 @@ namespace DynamicPanels
 		public Vector2 Position { get { return RectTransform.anchoredPosition; } }
 		public Vector2 Size { get { return RectTransform.sizeDelta; } }
 
-		private Vector2 m_minSize = new Vector2( 200f, 200f );
+		private Vector2 m_minSize = new Vector2( -1f, -1f );
 		public Vector2 MinSize
 		{
 			get { return m_minSize; }


### PR DESCRIPTION
**Issue**: Panel.m_minSize is initialized to (200, 200), but when an initial panel with smaller tabContent is added, the panel is created larger than the tabContent, because in PanelUtils.CreatePanel:
* the call to result.AddTab calls Internal.RecalculateMinSize, which updates m_minSize to the correct value
* but this ^ is done after setting `result.FloatingSize = contentRect.size;`, which already clamped the panel size to the initial (200, 200) value

**Fix:** avoid initializing Panel.m_minSize to a value > 0 to support creating panels smaller than (200, 200)